### PR TITLE
Add demo videos for Natural Chain and Truth Machine

### DIFF
--- a/demos/demo-catalog/natural-chain/README.md
+++ b/demos/demo-catalog/natural-chain/README.md
@@ -1,3 +1,7 @@
 # Natural Chain
 
 A natural gas supply chain proof of concept system leveraging the BSV blockchain that creates an incentivized data-provenance tracking for methane emissions across different supply chain stages. The demo shows how each party can view history, confirm/acknowledge receipt of items, triggering new transaction states with unique transaction IDs (txid).
+
+## Video Overview
+
+{% embed url="https://youtu.be/ct2MfN-h4l0" %}

--- a/demos/demo-catalog/truth-machine/README.md
+++ b/demos/demo-catalog/truth-machine/README.md
@@ -1,3 +1,7 @@
 # Truth Machine
 
 This application demonstrates secure data integrity and timestamping on the BSV Blockchain. Upload a file, and its cryptographic hash is recorded on the blockchain, creating an immutable proof of existence at that exact time. Files are stored in a regular database and can be retrieved later with verifiable evidence of their creation date and integrity. The Treasury section enables token creation to fund transaction fees for the service.
+
+## Video Overview
+
+{% embed url="https://youtu.be/SfAIL2vBjXE" %}


### PR DESCRIPTION
## Summary
- Adds a `## Video Overview` section with a GitBook video embed to `demos/demo-catalog/natural-chain/README.md` (https://youtu.be/ct2MfN-h4l0)
- Adds a `## Video Overview` section with a GitBook video embed to `demos/demo-catalog/truth-machine/README.md` (https://youtu.be/SfAIL2vBjXE)
- Matches the existing pattern established by the P2P Medical README

## Test plan
- [x] Confirm the embeds render correctly on GitBook for both demo pages
- [x] Confirm both videos play